### PR TITLE
base: Export connection vendor as postgresql

### DIFF
--- a/cockroach/django/base.py
+++ b/cockroach/django/base.py
@@ -12,7 +12,7 @@ from .schema import DatabaseSchemaEditor
 
 
 class DatabaseWrapper(PostgresDatabaseWrapper):
-    vendor = 'cockroachdb'
+    vendor = 'postgresql'
 
     # Override some types from the postgresql adapter.
     data_types = dict(


### PR DESCRIPTION
This PR changes the connection vendor for cockroachdb so that tests that
are postgresql only will be run automatically.

@timgraham I'll add you to PR's I submit here as well.