### PR TITLE
ci: Add teamcity continuous integration 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install python3 python3-dev python3-pip build-essential postgresql postgresql-contrib libpq-dev wget git

--- a/docker.sh
+++ b/docker.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Copyright 2017 The Cockroach Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License. See the AUTHORS file
+# for names of contributors.
+#
+# Author: Nikhil Benesch (nikhil.benesch@gmail.com)
+
+# This file is largely cargo-culted from cockroachdb/cockroach/build/builder.sh.
+
+set -euo pipefail
+
+image=local_teamcity_runner:latest
+
+gopath=$(go env GOPATH)
+gopath0=${gopath%%:*}
+
+# Absolute path to this repository.
+repo_root=$(cd "$(dirname "${0}")" && pwd)
+
+# Make a fake passwd file for the invoking user.
+#
+# This setup is so that files created from inside the container in a mounted
+# volume end up being owned by the invoking user and not by root.
+# We'll mount a fresh directory owned by the invoking user as /root inside the
+# container because the container needs a $HOME (without one the default is /)
+# and because various utilities (e.g. bash writing to .bash_history) need to be
+# able to write to there.
+username=$(id -un)
+uid_gid=$(id -u):$(id -g)
+container_root=${repo_root}/docker_root
+mkdir -p "${container_root}"/{etc,home,home/"${username}"/go/src}
+echo "${username}:x:${uid_gid}::/home/${username}:/bin/bash" > "${container_root}/etc/passwd"
+
+exec docker run \
+  --volume="${container_root}/etc/passwd:/etc/passwd" \
+  --volume="${container_root}/home/${username}:/home/${username}" \
+  --volume="${repo_root}:${repo_root}" \
+  --workdir="${repo_root}" \
+  --env=PIP_USER=1 \
+  --env=GEM_HOME="/home/${username}/.gems" \
+  --user="${uid_gid}" \
+  "$image" \
+  "$@"

--- a/teamcity-build/build-teamcity.sh
+++ b/teamcity-build/build-teamcity.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -x
+
+# install the cockroach-django driver.
+pip3 install psycopg2-binary
+pip3 install .
+
+# clone django into the repo.
+git clone https://github.com/django/django _django_repo
+
+# install the django requirements.
+cd _django_repo/tests/
+pip3 install -e ..
+pip3 install -r requirements/py3.txt
+pip3 install -r requirements/postgres.txt
+
+# download and start cockroach
+wget "https://binaries.cockroachdb.com/cockroach-v19.2.0-beta.20190930.linux-amd64.tgz"
+tar -xvf cockroach-v19.2*
+cp cockroach-v19.2*/cockroach cockroach_exec
+./cockroach_exec start --insecure &
+
+# Bring in the settings needed to run the tests with cockroach.
+cp ../../teamcity-build/cockroach_settings.py .
+
+# Run the tests!
+python3 ../../teamcity-build/runtests.py

--- a/teamcity-build/cockroach_settings.py
+++ b/teamcity-build/cockroach_settings.py
@@ -1,0 +1,14 @@
+DATABASES = {
+    'default': {
+        'ENGINE': 'cockroach.django',
+        'NAME' : 'django_tests',
+        'USER' : 'root',
+        'PASSWORD' : '',
+        'HOST': 'localhost',
+        'PORT' : 26257,
+    },
+}
+SECRET_KEY = 'django_tests_secret_key'
+PASSWORD_HASHERS = [
+    'django.contrib.auth.hashers.MD5PasswordHasher',
+]

--- a/teamcity-build/runtests.py
+++ b/teamcity-build/runtests.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+# This file assumes it is being run in the django/tests/ repo.
+
+# edit this list to include more test apps in the CI.
+enabled_test_apps = [
+    'app_loading',
+    'apps',
+    'base',
+    'bash_completion',
+    'update',
+]
+
+run_tests_cmd = "python3 runtests.py %s --settings cockroach_settings --parallel 1 -v 2"
+
+shouldFail = False
+for app_name in enabled_test_apps:
+    res = os.system(run_tests_cmd % app_name)
+    if res != 0:
+        shouldFail = True
+sys.exit(1 if shouldFail else 0)


### PR DESCRIPTION
This PR adds continuous integration for running parts of the django test
suite on teamcity. To adjust the django test apps that are executed in
the tests, edit the teamcity-build/runtests.py script.