### PR TITLE
Ignore partial indexes and PostgreSQL opclasses

### DIFF
--- a/cockroach/django/schema.py
+++ b/cockroach/django/schema.py
@@ -5,6 +5,11 @@ from django.db.backends.postgresql.schema import (
 
 
 class DatabaseSchemaEditor(PostgresDatabaseSchemaEditor):
+    # Partial indexes ('%(condition)s' in SQL string) aren't implemented in
+    # cockroachdb: https://github.com/cockroachdb/cockroach/issues/9683
+    # If implemented, this attribute can be removed.
+    sql_create_index = 'CREATE INDEX %(name)s ON %(table)s%(using)s (%(columns)s)%(extra)s'
+
     def _model_indexes_sql(self, model):
         # Postgres customizes _model_indexes_sql to add special-case
         # options for string fields. Skip to the base class version

--- a/cockroach/django/schema.py
+++ b/cockroach/django/schema.py
@@ -10,6 +10,10 @@ class DatabaseSchemaEditor(PostgresDatabaseSchemaEditor):
     # If implemented, this attribute can be removed.
     sql_create_index = 'CREATE INDEX %(name)s ON %(table)s%(using)s (%(columns)s)%(extra)s'
 
+    def _index_columns(self, table, columns, col_suffixes, opclasses):
+        # cockroachdb doesn't support PostgreSQL opclasses.
+        return BaseDatabaseSchemaEditor._index_columns(self, table, columns, col_suffixes, opclasses)
+
     def _model_indexes_sql(self, model):
         # Postgres customizes _model_indexes_sql to add special-case
         # options for string fields. Skip to the base class version

--- a/teamcity-build/runtests.py
+++ b/teamcity-build/runtests.py
@@ -10,6 +10,7 @@ enabled_test_apps = [
     'base',
     'bash_completion',
     'db_functions.text',
+    'indexes',
     'model_fields',
     'update',
 ]


### PR DESCRIPTION
The `indexes` tests now pass.