### PR TITLE
Enable PositiveIntegerField check constraints

### DIFF
--- a/cockroach/django/base.py
+++ b/cockroach/django/base.py
@@ -24,8 +24,6 @@ class DatabaseWrapper(PostgresDatabaseWrapper):
         PostgresDatabaseWrapper.data_types_suffix,
         AutoField='DEFAULT unique_rowid()',
     )
-    # Disable checks for positive values on some fields.
-    data_type_check_constraints = {}
 
     SchemaEditorClass = DatabaseSchemaEditor
     creation_class = DatabaseCreation

--- a/teamcity-build/runtests.py
+++ b/teamcity-build/runtests.py
@@ -9,6 +9,7 @@ enabled_test_apps = [
     'apps',
     'base',
     'bash_completion',
+    'model_fields',
     'update',
 ]
 


### PR DESCRIPTION
I guess support was added to cockroachdb since this comment. `model_fields` tests now pass.