### PR TITLE
Disable supports_regex_backreferencing feature

### DIFF
--- a/cockroach/django/features.py
+++ b/cockroach/django/features.py
@@ -59,3 +59,6 @@ class DatabaseFeatures(PostgresDatabaseFeatures):
     # Unlike PostgreSQL, cockroachdb doesn't support any EXPLAIN formats
     # ('JSON', 'TEXT', 'XML', and 'YAML').
     supported_explain_formats = set()
+
+    # Not implemented by cockroachdb: https://github.com/cockroachdb/cockroach/issues/41645
+    supports_regex_backreferencing = False


### PR DESCRIPTION
I'm not sure if there's an issue we can link to or if we should create one?

The test failure is:
```
======================================================================
ERROR: test_regex_backreferencing (lookup.tests.LookupTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/tim/code/django/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
psycopg2.InternalError: error parsing regexp: invalid escape sequence: `\1`


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/tim/code/django/django/test/testcases.py", line 1229, in skip_wrapper
    return test_func(*args, **kwargs)
  File "/home/tim/code/django/tests/lookup/tests.py", line 735, in test_regex_backreferencing
    ['<Article: barfoobaz>', '<Article: bazbaRFOO>', '<Article: foobarbaz>']
  File "/home/tim/code/django/django/test/testcases.py", line 1047, in assertQuerysetEqual
    items = map(transform, qs)
  File "/home/tim/code/django/django/db/models/query.py", line 274, in __iter__
    self._fetch_all()
  File "/home/tim/code/django/django/db/models/query.py", line 1242, in _fetch_all
    self._result_cache = list(self._iterable_class(self))
  File "/home/tim/code/django/django/db/models/query.py", line 55, in __iter__
    results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)
  File "/home/tim/code/django/django/db/models/sql/compiler.py", line 1100, in execute_sql
    cursor.execute(sql, params)
  File "/home/tim/code/django/django/db/backends/utils.py", line 67, in execute
    return self._execute_with_wrappers(sql, params, many=False, executor=self._execute)
  File "/home/tim/code/django/django/db/backends/utils.py", line 76, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "/home/tim/code/django/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
  File "/home/tim/code/django/django/db/utils.py", line 89, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/home/tim/code/django/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
django.db.utils.InternalError: error parsing regexp: invalid escape sequence: `\1`
```
SQL
```sql
SELECT ...
WHERE "lookup_article"."headline"::text ~ b(.).*b\1
```