### PR TITLE
Disable can_introspect_materialized_views feature

### DIFF
--- a/cockroach/django/features.py
+++ b/cockroach/django/features.py
@@ -62,3 +62,7 @@ class DatabaseFeatures(PostgresDatabaseFeatures):
 
     # Not implemented by cockroachdb: https://github.com/cockroachdb/cockroach/issues/41645
     supports_regex_backreferencing = False
+
+    # Introspection may work but 'CREATE MATERIALIZED VIEW' (required for the
+    # test) isn't implemented: https://github.com/cockroachdb/cockroach/issues/41649
+    can_introspect_materialized_views = False


### PR DESCRIPTION
todo: update comment with cockroach issue number. Current error points to a closed issue (https://github.com/cockroachdb/cockroach/issues/24747):
```
django.db.utils.NotSupportedError: at or near "inspectdb_people_materialized": syntax error: unimplemented: this syntax
DETAIL:  source SQL:
CREATE MATERIALIZED VIEW inspectdb_people_materialized AS SELECT id, name FROM inspectdb_people
                         ^
HINT:  You have attempted to use a feature that is not yet implemented.
See: https://github.com/cockroachdb/cockroach/issues/24747
```