### PR TITLE
ci: Change docker builder to use image from docker hub

### DIFF
--- a/docker.sh
+++ b/docker.sh
@@ -21,7 +21,7 @@
 
 set -euo pipefail
 
-image=local_teamcity_runner:latest
+image=cockroachdb/cockroach-django-builder:latest
 
 gopath=$(go env GOPATH)
 gopath0=${gopath%%:*}


### PR DESCRIPTION
This allows the agent to not have to rebuild the image locally.