### PR TITLE
Add 'other' database to Django test settings

### DIFF
--- a/cockroach/django/creation.py
+++ b/cockroach/django/creation.py
@@ -26,6 +26,7 @@ class DatabaseCreation(PostgresDatabaseCreation):
             # DATE_TRUNC result is incorrectly localized when a timezone is set:
             # https://github.com/cockroachdb/cockroach-django/issues/32
             'many_to_one.tests.ManyToOneTests.test_select_related',
+            'multiple_database.tests.QueryTestCase.test_basic_queries',
             'reserved_names.tests.ReservedNameTests.test_dates',
             # POWER() doesn't support negative exponents:
             # https://github.com/cockroachdb/cockroach-django/issues/22

--- a/teamcity-build/cockroach_settings.py
+++ b/teamcity-build/cockroach_settings.py
@@ -7,6 +7,14 @@ DATABASES = {
         'HOST': 'localhost',
         'PORT': 26257,
     },
+    'other': {
+        'ENGINE': 'cockroach.django',
+        'NAME': 'django_tests2',
+        'USER': 'root',
+        'PASSWORD': '',
+        'HOST': 'localhost',
+        'PORT': 26257,
+    },
 }
 SECRET_KEY = 'django_tests_secret_key'
 PASSWORD_HASHERS = [


### PR DESCRIPTION
Some tests require it.