### PR TITLE
ci: add expressions tests

### DIFF
--- a/cockroach/django/creation.py
+++ b/cockroach/django/creation.py
@@ -179,6 +179,8 @@ class DatabaseCreation(PostgresDatabaseCreation):
             # Number.objects.update(float=F('integer')) in setUpTestData(c)
             # https://github.com/cockroachdb/cockroach-django/issues/20
             'expressions.tests.ExpressionsNumericTests',
+            # Requires savepoints: https://github.com/cockroachdb/cockroach/issues/10735
+            'test_utils.tests.TestBadSetUpTestData',
         )
         for test_class in skip_classes:
             test_module_name, _, test_class_name = test_class.rpartition('.')

--- a/cockroach/django/operations.py
+++ b/cockroach/django/operations.py
@@ -18,7 +18,8 @@ class DatabaseOperations(PostgresDatabaseOperations):
     we specify a tzinfo then psycopg2 will cast it to a TIMESTAMPTZ
     """
     def adapt_datetimefield_value(self, value):
-        if value is not None and value.tzinfo is None and self.connection.timezone_name is not None:
+        # getattr() guards against F() objects which don't have tzinfo.
+        if value and getattr(value, 'tzinfo', '') is None and self.connection.timezone_name is not None:
             connection_timezone = timezone(self.connection.timezone_name)
             return connection_timezone.localize(value)
         return value

--- a/teamcity-build/runtests.py
+++ b/teamcity-build/runtests.py
@@ -49,7 +49,7 @@ enabled_test_apps = [
     'delete_regress',
     'distinct_on_fields',
     'empty',
-    # 'expressions',
+    'expressions',
     'expressions_case',
     'expressions_window',
     'extra_regress',

--- a/teamcity-build/runtests.py
+++ b/teamcity-build/runtests.py
@@ -146,7 +146,7 @@ enabled_test_apps = [
     'syndication_tests',
     'test_client',
     'test_client_regress',
-    # 'test_utils',
+    'test_utils',
     # 'timezones',
     'transaction_hooks',
     'transactions',


### PR DESCRIPTION
Also, fix expressions.tests.IterableLookupInnerExpressionsTests.test_in_lookup_allows_F_expressions_and_expressions_for_datetimes crash

