### PR TITLE
add support for CockroachDB 26.3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,6 +57,11 @@ jobs:
             use_psycopg2: psycopg2
           - crdb-version: v26.2.1
             use_server_side_binding: server_side_binding
+          - crdb-version: v26.3.0-rc.1
+          - crdb-version: v26.3.0-rc.1
+            use_psycopg2: psycopg2
+          - crdb-version: v26.3.0-rc.1
+            use_server_side_binding: server_side_binding
           # Uncomment to enable testing of CockroachDB nightly.
           #- crdb-version: LATEST
           #- crdb-version: LATEST

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 6.0.1 - Unreleased
+## 6.0.1 - 2026-07-29
 
 - Confirmed support for CockroachDB 26.1.x and 26.2.x (no code changes
   required).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 - Confirmed support for CockroachDB 26.1.x and 26.2.x (no code changes
   required).
 
+- Added support for CockroachDB 26.3.x. This version of CockroachDB reports
+  itself as PostgreSQL 18 (increased from version 13 in prior versions).
+  Several Django feature flags are adjusted to account for behavioral
+  differences between PostgreSQL and CockroachDB to maintain correct behavior.
+
 ## 6.0 - 2025-12-05
 
 Initial release for Django 6.0.x and CockroachDB 24.1.x, 24.3.x, 25.2.x,

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ By default, CockroachDB sends the version of django-cockroachdb that you're
 using back to Cockroach Labs. To disable this, set
 `DISABLE_COCKROACHDB_TELEMETRY = True` in your Django settings.
 
-## Known issues and limitations in CockroachDB 26.2.x and earlier
+## Known issues and limitations in CockroachDB 26.3.x and earlier
 
 - CockroachDB [can't disable constraint checking](https://github.com/cockroachdb/cockroach/issues/19444),
   which means certain things in Django like forward references in fixtures
@@ -106,11 +106,13 @@ using back to Cockroach Labs. To disable this, set
 - The `Field.db_comment` and `Meta.db_table_comment` options aren't supported
   due to [poor performance](https://github.com/cockroachdb/cockroach/issues/95068).
 
+- The `AnyValue` database function [isn't supported](https://github.com/cockroachdb/cockroach/issues/172590).
+
+- `UniqueConstraint.nulls_distinct` [isn't supported](https://github.com/cockroachdb/cockroach/issues/115836).
+
 - Unsupported queries:
    - [Mixed type addition in SELECT](https://github.com/cockroachdb/django-cockroachdb/issues/19):
      `unsupported binary operator: <int> + <float>`
-   - [Division that yields a different type](https://github.com/cockroachdb/django-cockroachdb/issues/21):
-     `unsupported binary operator: <int> / <int> (desired <int>)`
    - [The power() database function doesn't accept negative exponents](https://github.com/cockroachdb/django-cockroachdb/issues/22):
      `power(): integer out of range`
    - [sum() doesn't support arguments of different types](https://github.com/cockroachdb/django-cockroachdb/issues/73):
@@ -122,15 +124,12 @@ using back to Cockroach Labs. To disable this, set
 - GIS:
    - Some database functions aren't supported: `AsGML`, `AsKML`, `AsSVG`,
      and `GeometryDistance`.
-   - Some 3D functions or signatures aren't supported: `ST_3DPerimeter`,
-     `ST_3DExtent`, `ST_Scale`, and `ST_LengthSpheroid`.
+   - Some 3D functions or signatures aren't supported: `ST_3DExtent`,
+     `ST_Scale`, and `ST_LengthSpheroid`.
    - The `Length` database function isn't supported on geodetic fields:
      [st_lengthspheroid(): unimplemented](https://github.com/cockroachdb/cockroach/issues/48968).
    - `Union` may crash with
      [unknown signature: st_union(geometry, geometry)](https://github.com/cockroachdb/cockroach/issues/49064).
-   - The spheroid argument of ST_DistanceSpheroid
-     [isn't supported](https://github.com/cockroachdb/cockroach/issues/48922):
-     `unknown signature: st_distancespheroid(geometry, geometry, string)`.
    - These lookups aren't supported:
      - [contained (@)](https://github.com/cockroachdb/cockroach/issues/56124)
      - [exact/same_as (~=)](https://github.com/cockroachdb/cockroach/issues/57096)
@@ -138,6 +137,17 @@ using back to Cockroach Labs. To disable this, set
      - [overlaps_left (&<), overlaps_right (&>), overlaps_above (&<|),
        overlaps_below (&>|)](https://github.com/cockroachdb/cockroach/issues/57098)
      - [strictly_above (|>>), strictly_below (<<|)](https://github.com/cockroachdb/cockroach/issues/57095)
+
+## Known issues and limitations in CockroachDB 26.2.x and earlier
+
+- GIS:
+   - The `ST_3DPerimeter` function [isn't supported](https://github.com/cockroachdb/cockroach/issues/60871).
+   - The spheroid argument of `ST_DistanceSpheroid`
+     [isn't supported](https://github.com/cockroachdb/cockroach/issues/48922).
+
+- Queries which use [division that yields a different
+  type](https://github.com/cockroachdb/django-cockroachdb/issues/21) aren't
+  supported: `unsupported binary operator: <int> / <int> (desired <int>)`
 
 ## Known issues and limitations in CockroachDB 24.3.x and earlier
 

--- a/django_cockroachdb/__init__.py
+++ b/django_cockroachdb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '6.0'
+__version__ = '6.0.1'
 
 # Check Django compatibility before other imports which may fail if the
 # wrong version of Django is installed.

--- a/django_cockroachdb/features.py
+++ b/django_cockroachdb/features.py
@@ -48,6 +48,12 @@ class DatabaseFeatures(PostgresDatabaseFeatures):
     # https://github.com/cockroachdb/cockroach/issues/95068
     supports_comments = False
 
+    # Not supported: https://github.com/cockroachdb/cockroach/issues/172590
+    supports_any_value = False
+
+    # Not supported: https://github.com/cockroachdb/cockroach/issues/115836
+    supports_nulls_distinct_unique_constraints = False
+
     @cached_property
     def introspected_field_types(self):
         return {
@@ -94,6 +100,10 @@ class DatabaseFeatures(PostgresDatabaseFeatures):
     @cached_property
     def is_cockroachdb_26_1(self):
         return self.connection.cockroachdb_version >= (26, 1)
+
+    @cached_property
+    def is_cockroachdb_26_3(self):
+        return self.connection.cockroachdb_version >= (26, 3)
 
     @cached_property
     def django_test_expected_failures(self):
@@ -269,8 +279,6 @@ class DatabaseFeatures(PostgresDatabaseFeatures):
                 'db_functions.text.test_concat.ConcatTests.test_concat_non_str',
                 # unsupported binary operator: <interval> / <decimal>
                 'expressions.tests.FTimeDeltaTests.test_durationfield_multiply_divide',
-                # InvalidParameterValue: unsupported binary operator: <int4> / <float>
-                'queries.tests.Ticket23605Tests.test_ticket_23605',
                 # InvalidParameterValue: unsupported binary operator: <int2> + <float>
                 'annotations.tests.NonAggregateAnnotationTestCase.test_combined_annotation_commutative',
                 # incompatible COALESCE expressions: unsupported binary
@@ -279,6 +287,11 @@ class DatabaseFeatures(PostgresDatabaseFeatures):
                 # could not parse "@" as type timestamptz: parsing as type timestamp: empty or blank input
                 "aggregation.tests.AggregateTestCase.test_string_agg_order_by",
             })
+            if not self.is_cockroachdb_26_3:
+                expected_failures.update({
+                    # InvalidParameterValue: unsupported binary operator: <int4> / <float>
+                    'queries.tests.Ticket23605Tests.test_ticket_23605',
+                })
             if self.is_cockroachdb_24_3:
                 expected_failures.update({
                     # psycopg.errors.IndeterminateDatatype: replace():
@@ -306,7 +319,7 @@ class DatabaseFeatures(PostgresDatabaseFeatures):
                     'filtered_relation.tests.FilteredRelationTests.test_condition_with_func_and_lookup_outside_relation_name',  # noqa
                     'select_for_update.tests.SelectForUpdateTests.test_for_update_of_values_list',
                 })
-        else:
+        elif not self.is_cockroachdb_26_3:
             expected_failures.update({
                 # Unsupported query: unsupported binary operator: <int> / <int>:
                 # https://github.com/cockroachdb/django-cockroachdb/issues/21

--- a/django_cockroachdb/functions.py
+++ b/django_cockroachdb/functions.py
@@ -1,7 +1,7 @@
 import datetime
 
 from django.db.models import (
-    DateTimeField, DecimalField, FloatField, IntegerField,
+    DateTimeField, DecimalField, FloatField, IntegerField, TextField,
 )
 from django.db.models.expressions import When
 from django.db.models.functions import (
@@ -46,6 +46,52 @@ def float_cast(self, compiler, connection, **extra_context):
     return clone.as_sql(compiler, connection, **extra_context)
 
 
+def json_array(self, compiler, connection, **extra_context):
+    # Django uses json_array() for PostgreSQL 16+. CockroachDB 26.3+ reports
+    # itself as PostgreSQL 18 but doesn't support it:
+    # https://github.com/cockroachdb/cockroach/issues/172633.
+    # When it does, this function can be removed.
+    casted_obj = self.copy()
+    casted_obj.set_source_expressions(
+        [
+            (
+                # Conditional Cast to avoid unnecessary wrapping.
+                expression
+                if isinstance(expression, Cast)
+                else Cast(expression, expression.output_field)
+            )
+            for expression in casted_obj.get_source_expressions()
+        ]
+    )
+    return casted_obj.as_sql(
+        compiler,
+        connection,
+        function="JSONB_BUILD_ARRAY",
+        **extra_context,
+    )
+
+
+def json_object(self, compiler, connection, **extra_context):
+    # Django uses json_object([{ key_expression { VALUE | ':' }
+    # value_expression }]) for PostgreSQL 16+. CockroachDB 26.3+ reports itself
+    # as PostgreSQL 18 but doesn't support it:
+    # https://github.com/cockroachdb/cockroach/issues/172638.
+    # When it does, this function can be removed.
+    copy = self.copy()
+    copy.set_source_expressions(
+        [
+            Cast(expression, TextField()) if index % 2 == 0 else expression
+            for index, expression in enumerate(copy.get_source_expressions())
+        ]
+    )
+    return super(JSONObject, copy).as_sql(
+        compiler,
+        connection,
+        function="JSONB_BUILD_OBJECT",
+        **extra_context,
+    )
+
+
 def round_cast(self, compiler, connection, **extra_context):
     # ROUND() doesn't accept integer values. Cast to decimal (rather than
     # float) so that half away from zero rounding is used, consistent with
@@ -77,8 +123,8 @@ def register_functions():
         func.as_cockroachdb = float_cast
     Coalesce.as_cockroachdb = coalesce
     Collate.as_cockroachdb = collate
-    JSONArray.as_cockroachdb = JSONArray.as_postgresql
-    JSONObject.as_cockroachdb = JSONObject.as_postgresql
+    JSONArray.as_cockroachdb = json_array
+    JSONObject.as_cockroachdb = json_object
     Now.as_cockroachdb = Now.as_postgresql
     Round.as_cockroachdb = round_cast
     StrIndex.as_cockroachdb = StrIndex.as_postgresql

--- a/django_cockroachdb_gis/features.py
+++ b/django_cockroachdb_gis/features.py
@@ -27,6 +27,7 @@ class DatabaseFeatures(CockroachFeatures, PostGISFeatures):
             'gis_tests.relatedapp.tests.RelatedGeoModelTest.test06_f_expressions',
             # unknown signature: st_union(geometry, geometry)
             # https://github.com/cockroachdb/cockroach/issues/49064
+            'gis_tests.distapp.tests.DistanceTest.test_distance_lookups_with_expression_rhs',
             'gis_tests.distapp.tests.DistanceTest.test_dwithin',
             'gis_tests.geoapp.test_functions.GISFunctionsTests.test_diff_intersection_union',
             'gis_tests.geoapp.test_functions.GISFunctionsTests.test_union_mixed_srid',
@@ -35,20 +36,12 @@ class DatabaseFeatures(CockroachFeatures, PostGISFeatures):
             'gis_tests.geoapp.tests.GeoLookupTest.test_relate_lookup',
             # NotSupportedError: this box2d comparison operator is experimental
             'gis_tests.geoapp.tests.GeoLookupTest.test_contains_contained_lookups',
-            # unknown signature: st_distancespheroid(geometry, geometry, string)
-            # https://github.com/cockroachdb/cockroach/issues/48922#issuecomment-693096502
-            'gis_tests.distapp.tests.DistanceTest.test_distance_lookups_with_expression_rhs',
-            'gis_tests.distapp.tests.DistanceTest.test_geodetic_distance_lookups',
-            'gis_tests.distapp.tests.DistanceFunctionsTests.test_distance_geodetic_spheroid',
             # st_lengthspheroid(): unimplemented:
             # https://github.com/cockroachdb/cockroach/issues/48968
             'gis_tests.distapp.tests.DistanceFunctionsTests.test_length',
             # Unsupported ~= (https://github.com/cockroachdb/cockroach/issues/57096)
             # and @ operators (https://github.com/cockroachdb/cockroach/issues/56124).
             'gis_tests.geogapp.tests.GeographyTest.test_operators_functions_unavailable_for_geography',
-            # unknown function: st_3dperimeter
-            # https://github.com/cockroachdb/cockroach/issues/60871
-            'gis_tests.geo3d.tests.Geo3DFunctionsTests.test_perimeter',
             # unknown function: st_3dextent()
             # https://github.com/cockroachdb/cockroach/issues/60864
             'gis_tests.geo3d.tests.Geo3DTest.test_extent',
@@ -84,5 +77,15 @@ class DatabaseFeatures(CockroachFeatures, PostGISFeatures):
                 # unknown signature: st_dwithin(geography, geometry, decimal) (desired <bool>)
                 # https://github.com/cockroachdb/cockroach/issues/53720
                 'gis_tests.geogapp.tests.GeographyTest.test02_distance_lookup',
+            })
+        if not self.is_cockroachdb_26_3:
+            expected_failures.update({
+                # unknown signature: st_distancespheroid(geometry, geometry, string)
+                # https://github.com/cockroachdb/cockroach/issues/48922#issuecomment-693096502
+                'gis_tests.distapp.tests.DistanceTest.test_geodetic_distance_lookups',
+                'gis_tests.distapp.tests.DistanceFunctionsTests.test_distance_geodetic_spheroid',
+                # unknown function: st_3dperimeter
+                # https://github.com/cockroachdb/cockroach/issues/60871
+                'gis_tests.geo3d.tests.Geo3DFunctionsTests.test_perimeter',
             })
         return expected_failures


### PR DESCRIPTION
I'd like to merge this even with the release candidate version of CockroachDB 26.3 so that it'll be on the Django 6.0 branch in advance of adding Django 6.1 support next week.