### PR TITLE
ci: add "permissions: contents: read" to workflows

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -7,6 +7,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   flake8:
     name: flake8

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # This job aggregates all matrix results and is used for a GitHub required status check.
   test_results:


### PR DESCRIPTION
Pins this workflow to `permissions: contents: read` at the top level. The lint/test path checks out the repo, sets up Python, installs requirements and runs the linter/test suite; no API call beyond the initial checkout.

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) is the canonical case for caring about per-workflow caps: a tampered third-party action exfiltrated `GITHUB_TOKEN` from workflow logs and the blast radius matched whatever scope was issued. Capping at the workflow's actual minimum bounds the runtime authority of every action that runs inside it, independent of the org default, and gives drift protection if that default ever widens. OpenSSF Scorecard's Token-Permissions check credits only the explicit per-workflow block.

YAML validated locally with `yaml.safe_load`.
